### PR TITLE
error occurred if subresources == null

### DIFF
--- a/src/Client/Request.php
+++ b/src/Client/Request.php
@@ -186,7 +186,7 @@ class Request
     {
         $url = $this->getResourceUrl($this->resource, $this->idParam);
 
-        if (count($this->subresources)) {
+        if ($this->subresources && count($this->subresources)) {
             foreach($this->subresources as $subresource) {
                 if ($subresource['name']) {
                     $url .= $this->getResourceUrl($subresource['name'], $subresource['id']);


### PR DESCRIPTION
Error occurred when running tests in file_parser.
Now we check if subresources is exist, after this check his count.